### PR TITLE
Update CI to orb v4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2.1
 
 # Anchors in case we need to override the defaults from the orb
-#baselibs_version: &baselibs_version v7.17.0
-#bcs_version: &bcs_version v11.4.0
+#baselibs_version: &baselibs_version v7.27.0
+#bcs_version: &bcs_version v11.6.0
 
 orbs:
-  ci: geos-esm/circleci-tools@2
+  ci: geos-esm/circleci-tools@4
 
 workflows:
   build-test:


### PR DESCRIPTION
This updates the CI to be able to test with recent GEOSgcm updates.